### PR TITLE
Improve player aiming and zombie waves

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -24,9 +24,9 @@ class Game {
         this.waveTimer = 0;
         this.waveDelay = 3000;
         this.baseEnemiesPerWave = 3;
-        this.baseZombiesPerWave = 6;
+        this.baseZombiesPerWave = 10;
         this.maxEnemiesPerWave = 10;
-        this.maxZombiesPerWave = 20;
+        this.maxZombiesPerWave = 30;
         
         this.gameState = 'menu';
         this.selectedHero = null;

--- a/js/Particle.js
+++ b/js/Particle.js
@@ -1,10 +1,11 @@
 class Particle {
-    constructor(x, y, type, assetLoader, frameCount = 20) {
+    constructor(x, y, type, assetLoader, frameCount = 20, angle = 0) {
         this.x = x;
         this.y = y;
         this.type = type;
         this.assetLoader = assetLoader;
         this.alive = true;
+        this.angle = angle;
         
         if (type === 'explosion') {
             this.frames = [];
@@ -88,23 +89,24 @@ class Particle {
         if (this.animation) {
             const frame = this.animation.getCurrentFrame();
             if (frame) {
-                ctx.drawImage(frame, 
-                    screenX - this.width/2, 
-                    screenY - this.height/2, 
-                    this.width, 
-                    this.height
-                );
+                ctx.save();
+                ctx.translate(screenX, screenY);
+                if (this.angle) {
+                    ctx.rotate(this.angle);
+                }
+                ctx.drawImage(frame, -this.width/2, -this.height/2, this.width, this.height);
+                ctx.restore();
             }
         } else {
             ctx.save();
-            
+
             if (this.lifetime) {
                 ctx.globalAlpha = Math.max(0, this.lifetime / 500);
             }
-            
+
             ctx.fillStyle = this.color || '#fff';
             ctx.fillRect(screenX - this.width/2, screenY - this.height/2, this.width, this.height);
-            
+
             ctx.restore();
         }
     }

--- a/js/Player.js
+++ b/js/Player.js
@@ -202,6 +202,13 @@ class Player extends Entity {
         }
 
         this.handleMovement(deltaTime);
+
+        // Update facing direction based on mouse position so the player aims correctly
+        if (this.mouseX !== undefined && this.mouseY !== undefined) {
+            const worldMouseX = this.mouseX + game.camera.x;
+            this.facingRight = worldMouseX >= this.x + this.width / 2;
+        }
+
         this.handleShooting(deltaTime, game);
         this.updateAnimation();
         
@@ -259,19 +266,24 @@ class Player extends Entity {
     }
 
     shoot(game) {
-        // Position bullet at the player's gun/center
-        const bulletX = this.x + this.width / 2;
-        const bulletY = this.y + this.height / 2;
-        
+        // Base position from the player's center
+        const originX = this.x + this.width / 2;
+        const originY = this.y + this.height / 2;
+
         let angle = this.facingRight ? 0 : Math.PI;
-        
+
         if (this.mouseX !== undefined && this.mouseY !== undefined) {
             const camera = game.camera;
             const worldMouseX = this.mouseX + camera.x;
             const worldMouseY = this.mouseY + camera.y;
-            angle = Math.atan2(worldMouseY - bulletY, worldMouseX - bulletX);
+            angle = Math.atan2(worldMouseY - originY, worldMouseX - originX);
         }
-        
+
+        // Offset bullet so it spawns at the muzzle of the gun
+        const offset = 32;
+        const bulletX = originX + Math.cos(angle) * offset;
+        const bulletY = originY + Math.sin(angle) * offset;
+
         const bullet = new Bullet(bulletX, bulletY, angle, this.team, this.assetLoader);
         game.bullets.push(bullet);
 
@@ -280,7 +292,8 @@ class Player extends Entity {
             bulletY,
             'muzzle',
             this.assetLoader,
-            5
+            5,
+            angle
         );
         game.particles.push(muzzleFlash);
     }


### PR DESCRIPTION
## Summary
- Align player facing with mouse aim and spawn bullets from muzzle
- Rotate muzzle flash particles and offset them to gun barrel
- Increase zombie numbers for each wave

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f3ddade0832f89c4abc3b69b70fb